### PR TITLE
Fixed content overlapping with fixed navbar

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -102,7 +102,7 @@ const Home = () => {
   }, [controls]);
 
   return (
-    <div className="min-h-[80vh] mt-[5%] rounded-2xl lg:min-h-screen bg-gradient-to-br from-[#0a0415] via-[#11071f] to-[#1a0b2e] relative overflow-hidden flex flex-col justify-center items-center">
+    <div className="min-h-[80vh] pt-[80px] lg:pt-[90px] rounded-2xl lg:min-h-screen bg-gradient-to-br from-[#0a0415] via-[#11071f] to-[#1a0b2e] relative overflow-hidden flex flex-col justify-center items-center">
       <div
         style={{
           width: "100%",


### PR DESCRIPTION

## 📄 Description
Fixed the issue where the "Your Journey to Full-Stack Excellence" banner text  was overlapping with the fixed navbar, making it partially hidden.  
Adjusted the top spacing using padding instead of margin to ensure the text is always visible across all screen sizes.

## ✅ Checklist
- [x] My code follows the project’s coding guidelines.
- [x] I have tested these changes locally.

## 🔗 Related Issue
Closes #82

<img width="1920" height="1080" alt="Screenshot (131)" src="https://github.com/user-attachments/assets/3198eed8-8ae7-4631-bbf0-6c1701bda452" />

<img width="1014" height="987" alt="Screenshot 2025-08-11 210834" src="https://github.com/user-attachments/assets/fb880ca1-1044-4c0b-b07e-236b7416d23e" />
