### PR TITLE
Update navigation behavior to redirect to first child path if available ISSUE #127

### DIFF
--- a/src/components/gloable/Header.jsx
+++ b/src/components/gloable/Header.jsx
@@ -343,7 +343,12 @@ export function Header() {
                   <button
                     key={item.name}
                     onClick={() => {
-                      window.location.href = item.path;
+                      // If item has children, go to first child's path (Docs)
+                      if (item.children && item.children.length > 0) {
+                        window.location.href = item.children[0].path;
+                      } else {
+                        window.location.href = item.path;
+                      }
                       setMenuOpen(false);
                     }}
                     className={`group flex items-center gap-4 px-4 py-3 rounded-xl bg-gray-900/50 backdrop-blur-sm border border-gray-700/50 hover:border-purple-500/50 transition-all duration-300 hover:scale-105 hover:shadow-lg ${item.color} hover:shadow-purple-500/25 w-full`}


### PR DESCRIPTION
Fix mobile menu navigation for main sections

Updated the mobile menu logic so that clicking a main section (e.g., Frontend, Backend, DSA, etc.) now navigates to the correct Docs page instead of /undefined.
The fix applies only to mobile view; desktop navigation remains unchanged.
Ensured all main sidebar fields route to their respective first child (Docs) for a consistent user experience on mobile devices.

Issue #127 